### PR TITLE
Increase client timeout to 60s

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@depot/actions-public-oidc-client",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -39,7 +39,7 @@ export async function getIDToken(aud?: string): Promise<string> {
   }, 1000)
 
   try {
-    for (let i = 1; i < 5; i++) {
+    for (let i = 1; i < 60; i++) {
       const res = await client.post(exchangeURL, '')
       if (res.message.statusCode === 200) return await res.readBody()
       await sleep(1000)


### PR DESCRIPTION
The issuer now immediately returns a validated result, so we should retry for the full 60s on the client side.