### PR TITLE
Global placement causes a recursion error

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,3 @@ new_classes = ["Claim"]
 [[migrations]]
 tag = "v2"
 new_classes = ["Watcher"]
-
-[placement]
-mode = "smart"


### PR DESCRIPTION
Global placement seems to have some kind of recursion error in workers at the moment. I've turned it off to bring public OIDC token exchanges back online. https://community.cloudflare.com/t/worker-throwing-recursion-error-when-calling-a-durable-object-even-though-there-is/640749/4