### PR TITLE
Add retries for validating claims

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,19 @@
+interface RetryOptions {
+  retries?: number
+  delay?: number
+}
+
+export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}) {
+  const {retries = 3, delay = 1000} = options
+
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (i >= retries - 1) throw err
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+
+  throw new Error('unreachable')
+}


### PR DESCRIPTION
Sometimes the GitHub API can lag behind the actual Actions run - this introduces up to 4 retries with 2 seconds of delay between each to validate the run.