### PR TITLE
Send attempt number from OIDC client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@depot/actions-public-oidc-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -22,6 +22,7 @@ export async function getIDToken(aud?: string): Promise<string> {
     eventName: github.context.eventName,
     repo: `${github.context.repo.owner}/${github.context.repo.repo}`,
     runID: github.context.runId.toString(),
+    attempt: process.env.GITHUB_RUN_ATTEMPT,
   })
 
   if (res.statusCode >= 400) {


### PR DESCRIPTION
[Like our CLI](https://github.com/depot/cli/pull/326), we need to send the Actions run attempt number from the TypeScript client if known, to avoid accidentally selecting an older attempt during token exchange and failing.