### PR TITLE
Update validators

### DIFF
--- a/src/durable-objects/Claim.ts
+++ b/src/durable-objects/Claim.ts
@@ -1,8 +1,10 @@
 import {DurableObject} from 'cloudflare:workers'
 import {addSeconds} from 'date-fns'
-import {ClaimSchema, Env, claimSchema} from '../types'
+import type {ClaimSchema, Env} from '../types'
+import {claimSchema} from '../types'
 import {validateClaim} from '../utils/github'
-import {Key, issueToken} from '../utils/oidc'
+import type {Key} from '../utils/oidc'
+import {issueToken} from '../utils/oidc'
 import {retry} from '../utils/retry'
 
 export interface InitData {
@@ -12,10 +14,6 @@ export interface InitData {
 }
 
 export class Claim extends DurableObject<Env['Bindings']> {
-  constructor(ctx: DurableObjectState, env: Env['Bindings']) {
-    super(ctx, env)
-  }
-
   async claim(data: InitData) {
     const result = claimSchema.safeParse(data.claimData)
     if (!result.success) throw new Error(`Invalid claim: ${result.error.issues}`)

--- a/src/durable-objects/Watcher.ts
+++ b/src/durable-objects/Watcher.ts
@@ -4,6 +4,7 @@ import {DurableObject} from 'cloudflare:workers'
 import {addSeconds} from 'date-fns'
 import type {Env} from '../types'
 import {EventIterator} from '../utils/EventIterator'
+import {userAgent} from '../utils/userAgent'
 
 export interface InitData {
   websocketURL: string
@@ -99,8 +100,7 @@ async function startWebsocketWatcher(
     headers: {
       Accept: 'application/json',
       Cookie: `user_session=${session}`,
-      'User-Agent':
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+      'User-Agent': userAgent,
     },
   })
   const body = await res.json<{data?: {authenticated_url: string}}>()

--- a/src/durable-objects/Watcher.ts
+++ b/src/durable-objects/Watcher.ts
@@ -2,7 +2,7 @@ import {StableSocket} from '@github/stable-socket'
 import {isAbortError} from 'abort-controller-x'
 import {DurableObject} from 'cloudflare:workers'
 import {addSeconds} from 'date-fns'
-import {Env} from '../types'
+import type {Env} from '../types'
 import {EventIterator} from '../utils/EventIterator'
 
 export interface InitData {
@@ -14,10 +14,6 @@ export class Watcher extends DurableObject<Env['Bindings']> {
   watcher: Promise<void> | undefined
   controller: AbortController | undefined
   challenges: Map<string, boolean> = new Map()
-
-  constructor(state: DurableObjectState, env: Env['Bindings']) {
-    super(state, env)
-  }
 
   async validate({websocketURL, challengeCode}: InitData) {
     await this.ctx.storage.setAlarm(addSeconds(new Date(), 60))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import {Hono} from 'hono'
-import {InitData} from './durable-objects/Claim'
-import {Env} from './types'
+import type {InitData} from './durable-objects/Claim'
+import type {Env} from './types'
 import {authenticateAdmin} from './utils/auth'
-import {Key, generateKey} from './utils/oidc'
+import type {Key} from './utils/oidc'
+import {generateKey} from './utils/oidc'
 
 const app = new Hono<Env>()
 export default app

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod'
-import {Claim} from './durable-objects/Claim'
-import {Watcher} from './durable-objects/Watcher'
+import type {Claim} from './durable-objects/Claim'
+import type {Watcher} from './durable-objects/Watcher'
 
 export const claimSchema = z.object({
   aud: z.string().optional(),

--- a/src/utils/EventIterator.ts
+++ b/src/utils/EventIterator.ts
@@ -97,7 +97,7 @@ class EventQueue<T> {
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
     return {
-      next: (value?: any) => {
+      next: (_value?: unknown) => {
         const result = this.pushQueue.shift()
         if (result) {
           if (this.lowWaterMark !== undefined && this.pushQueue.length <= this.lowWaterMark && this.isPaused) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,7 @@
-import {HonoRequest} from 'hono'
-import {Env} from '../types'
+import type {HonoRequest} from 'hono'
+import type {Env} from '../types'
 
-export async function authenticateAdmin(env: Env['Bindings'], req: HonoRequest<any>) {
+export async function authenticateAdmin(env: Env['Bindings'], req: HonoRequest<string>) {
   const header = req.header('authorization')
   if (!header) throw new Error('missing authorization header')
   const [type, token] = header.split(' ')

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -76,16 +76,6 @@ export async function validateClaim(
         return {jobID, validated}
       }),
     )
-
-    promises.push(
-      validateChallengeCode(
-        env,
-        `https://github.com/${claimData.owner}/${claimData.repo}/commit/${headSHA}/checks/${jobID}/live_logs`,
-        challengeCode,
-      ).then((validated) => {
-        return {jobID, validated}
-      }),
-    )
   }
 
   const all = await Promise.allSettled(promises)
@@ -130,12 +120,6 @@ export async function validateClaim(
   }
 
   return validatedClaims
-}
-
-async function validateChallengeCode(env: Env['Bindings'], url: string, code: string): Promise<boolean> {
-  const stub = env.WATCHER.get(env.WATCHER.idFromName(url))
-  const data = await stub.validate({websocketURL: url, challengeCode: code})
-  return data.validated
 }
 
 interface BackscrollArgs {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,5 +1,5 @@
 import {request} from '@octokit/request'
-import {Env, TokenClaims} from '../types'
+import type {Env, TokenClaims} from '../types'
 
 interface ClaimData {
   owner: string
@@ -61,8 +61,6 @@ export async function validateClaim(
     const jobID = job.id
     const headSHA = job.head_sha
     if (!jobID || !headSHA) continue
-
-    const jobURL = `https://github.com/${claimData.owner}/${claimData.repo}/actions/runs/${claimData.runID}/jobs/${jobID}`
 
     promises.push(
       validateChallengeCodeWithBackscroll({

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -175,12 +175,14 @@ async function validateChallengeCodeWithBackscroll(args: BackscrollArgs): Promis
           })
           const body = (await backscrollRes.json()) as {lines?: {line: string}[]}
 
+          if (Array.isArray(body.lines)) {
+            body.lines.reverse()
+          }
+
           if (body.lines?.some((line) => line.line.includes(code))) {
             console.log(`Challenge ${code} validated with backscroll`, args)
             return true
           }
-
-          console.log(body)
         } catch (e) {
           console.log('Error checking backscroll for step', step, e)
         }

--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -1,5 +1,5 @@
 import {base64url} from 'rfc4648'
-import {TokenClaims} from '../types'
+import type {TokenClaims} from '../types'
 
 const keyAlg = {
   name: 'RSASSA-PKCS1-v1_5',
@@ -20,7 +20,7 @@ export async function issueToken({issuer, audience, keyID, privateKey: privateKe
   const privateKey = await importPrivateKey(keyID, privateKeyData)
 
   const header = {alg: 'RS256', typ: 'JWT', kid: keyID}
-  const timestamp = Math.floor(Number(new Date()) / 1000) // seconds
+  const timestamp = Math.floor(Date.now() / 1000) // seconds
   const payload = {
     aud: audience,
     iss: issuer,

--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -1,0 +1,2 @@
+export const userAgent =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36'


### PR DESCRIPTION
* Remove `live_logs` validator, as this endpoint no longer exists
* Retry backscroll fetching with 1s delay
* Update user-agent
* Add improved logging