### PR TITLE
Fix session refresh cron job

### DIFF
--- a/support/refresh-session.ts
+++ b/support/refresh-session.ts
@@ -57,7 +57,7 @@ async function run() {
       page.getByRole('button', {name: 'Confirm'}).click(),
     ])
     await Promise.race([
-      await page.getByTitle(process.env.USERNAME).click(),
+      page.getByTitle(process.env.USERNAME).click(),
       page.getByLabel('Open user account menu').click(),
       page.getByLabel('Open user navigation menu').click(),
     ])


### PR DESCRIPTION
The `await` here was preventing the `Promise.race()` from actually racing the promises, which broke the session refresh workflow.